### PR TITLE
Update urls.py

### DIFF
--- a/apps/webapp/urls.py
+++ b/apps/webapp/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
     # path(r"^api/films/schema$", "resources.schemas.films"),
     path('planets/', views.PlanetListView.as_view(), name='planets'),
     path('species/', views.SpeciesListView.as_view(), name='species'),
-    path('starships/', views.StarshipListView.as_view(), name='starships')
+    path('starships/', views.StarshipListView.as_view(), name='starships'),
     # path(r"^api/vehicles/schema$", "resources.schemas.vehicles"),
     # path(r"^api/starships/schema$", "resources.schemas.starships"),
     # path(r"^api/", include(router.urls)),


### PR DESCRIPTION
This PR fixes an error in urls.py. The urlpatterns list was missing a comma between starships and vehicles.