### PR TITLE
Fix FilmPerson; Fix Admin forms

### DIFF
--- a/apps/webapp/admin.py
+++ b/apps/webapp/admin.py
@@ -8,42 +8,45 @@ class FilmAdmin(admin.ModelAdmin):
     """Film administration."""
 
     fields = [
-        'film_id',
         'title',
         'episode_id',
         'opening_crawl',
         'director',
         'producer',
         'release_date',
-        # 'characters',
-        # 'planets',
-        # 'starships',
-        # 'vehicles',
-        # 'species'
     ]
-
     list_display = [
-        'film_id',
         'title',
         'episode_id',
         'opening_crawl',
         'director',
         'producer',
         'release_date',
-        'get_characters',
-        # 'get_planets',
-        # 'get_starships',
-        # 'get_vehicles',
-        # 'get_species'
+        'film_characters',
+        # 'film_planets',
+        # 'film_species',
+        # 'film_starships',
+        # 'film_vehicles'
     ]
-
+    list_filter = ['title']
     filter_horizontal = [
         'characters',
+        # 'planets',
+        # 'species',
+        # 'starships',
+        # 'vehicles'
     ]
-
     ordering = ['title']
 
-    list_filter = ['title']
+
+@admin.register(FilmPerson)
+class FilmPersonAdmin(admin.ModelAdmin):
+    """FilmPerson administration."""
+
+    fields = ['film', 'person']
+    list_display = ['film', 'person']
+    list_filter = ['film']
+    ordering = ['film', 'person']
 
 
 @admin.register(Person)
@@ -62,7 +65,6 @@ class PersonAdmin(admin.ModelAdmin):
         'skin_color',
         'home_world'
     ]
-
     list_display = [
         'name',
         'species',
@@ -75,10 +77,8 @@ class PersonAdmin(admin.ModelAdmin):
         'skin_color',
         'home_world'
     ]
-
-    ordering = ['name']
-
     list_filter = ['name']
+    ordering = ['name']
 
 
 @admin.register(Planet)
@@ -130,7 +130,6 @@ class SpeciesAdmin(admin.ModelAdmin):
         'language',
         'home_world'
     ]
-
     list_display = [
         'name',
         'classification',
@@ -143,10 +142,8 @@ class SpeciesAdmin(admin.ModelAdmin):
         'language',
         'home_world'
     ]
-
-    ordering = ['name']
-
     list_filter = ['name']
+    ordering = ['name']
 
 
 @admin.register(Starship)
@@ -168,7 +165,6 @@ class StarshipAdmin(admin.ModelAdmin):
         'consumables',
         'pilots'
     ]
-
     list_display = [
         'starship_class',
         'manufacturer',
@@ -183,10 +179,8 @@ class StarshipAdmin(admin.ModelAdmin):
         'consumables',
         'pilots'
     ]
-
-    ordering = ['name']
-
     list_filter = ['name']
+    ordering = ['name']
 
 
 @admin.register(Vehicles)
@@ -205,7 +199,6 @@ class VehiclesAdmin(admin.ModelAdmin):
         'cargo_capacity',
         'consumables'
     ]
-
     list_display = [
         'name',
         'vehicle_class',
@@ -218,25 +211,5 @@ class VehiclesAdmin(admin.ModelAdmin):
         'cargo_capacity',
         'consumables'
     ]
-
-    ordering = ['name']
-
     list_filter = ['name']
-
-@admin.register(FilmPerson)
-class FilmPersonAdmin(admin.ModelAdmin):
-    """FilmPerson administration."""
-
-    fields = [
-        'film',
-        'person'
-    ]
-
-    list_display = [
-        'film',
-        'person'
-    ]
-
-    ordering = ['film', 'person']
-
-    list_filter = ['film']
+    ordering = ['name']

--- a/apps/webapp/models.py
+++ b/apps/webapp/models.py
@@ -18,9 +18,9 @@ class Film(models.Model):
     # vehicles = models.ManyToManyField('Vehicle', related_name="film_vehicles", blank=True)
     # species = models.ManyToManyField('Species', related_name="film_species", blank=True)
 
-    def get_characters(self):
+    def film_characters(self):
         return "\n".join([character.name for character in self.characters.all()])
-    
+
     # def get_planets(self):
     #     return "\n".join([planet.url for planet in self.planets.all()])
 
@@ -34,7 +34,7 @@ class Film(models.Model):
     #     return "\n".join([species.url for species in self.species.all()])
 
     class Meta:
-        managed = True
+        managed = False
         db_table = 'film'
         ordering = ['title']
         verbose_name = 'Film'
@@ -49,6 +49,18 @@ class Film(models.Model):
     def __str__(self):
         return self.title
 
+
+class FilmPerson(models.Model):
+    film_person_id = models.AutoField(primary_key=True)
+    film = models.ForeignKey('Film', on_delete=models.CASCADE)
+    person = models.ForeignKey('Person', on_delete=models.CASCADE)
+
+    class Meta:
+        managed = False
+        db_table = 'film_person'
+        ordering = ['film', 'person']
+        verbose_name = 'Film Character'
+        verbose_name_plural = 'Film Characters'
 
 class Person(models.Model):
     """ A person i.e., Luke Skywalker. """
@@ -66,7 +78,7 @@ class Person(models.Model):
     home_world = models.ForeignKey('Planet', related_name="person_home_world", on_delete=models.PROTECT, blank=True, null=True)
 
     class Meta:
-        managed = True
+        managed = False
         db_table = 'person'
         ordering = ['name']
         verbose_name = 'Person'
@@ -97,7 +109,7 @@ class Planet(models.Model):
     population = models.CharField(max_length=40, blank=True, null=True)
 
     class Meta:
-        managed = True
+        managed = False
         db_table = 'planet'
         ordering = ['name']
         verbose_name = 'Planet'
@@ -126,7 +138,7 @@ class Species(models.Model):
     home_world = models.ForeignKey('Planet', related_name="species_home_world", on_delete=models.PROTECT, blank=True, null=True)
 
     class Meta:
-        managed = True
+        managed = False
         db_table = 'species'
         ordering = ['name']
         verbose_name = 'Species'
@@ -161,7 +173,7 @@ class Starship(models.Model):
     pilots = models.ForeignKey('Person', related_name='starship_person', on_delete=models.PROTECT, blank=True, null=True)
 
     class Meta:
-        managed = True
+        managed = False
         db_table = 'starship'
         ordering = ['name']
         verbose_name = 'Starship'
@@ -190,7 +202,7 @@ class Vehicles(models.Model):
     consumables = models.CharField(max_length=40, blank=True, null=True)
 
     class Meta:
-        managed = True
+        managed = False
         db_table = 'vehicles'
         ordering = ['name']
         verbose_name = 'Vehicle'
@@ -199,9 +211,4 @@ class Vehicles(models.Model):
     def __str___(self):
         return self.name
 
-
-class FilmPerson(models.Model):
-    # film_person_id = models.AutoField(primary_key=True)
-    film = models.ForeignKey('Film', on_delete=models.CASCADE)
-    person = models.ForeignKey('Person', on_delete=models.CASCADE)
     


### PR DESCRIPTION
This PR addresses issues with the implementation of M-M relationship between `Film` and `Person`.  It can serve as a model for adding additional M-M relationships.

Changes

1.  Disable Django management of back-end Db
2. Update `FilmPerson` adding class `Meta`
3. Change `Film.get_characters()` to `Film.film_characters()` (partly form column header display related)
4. Remove `film_id` from `FilmAdmin` (runtime exception)
5  Cleanup `admin.py`

The following SQL statements were run from the terminal in order to update `db.sqlite3`. Devs will need to run these locally after the PR is merged.  You can run them from inside VS Code if you have the SQLite extension enabled. 

I prefer using the sqlite CLI (command line) to run the following SQL statements:

```sql
-- SQLite
ALTER TABLE film_characters
RENAME TO film_person;
```

```sql
-- SQLite
ALTER TABLE film_characters
RENAME COLUMN id TO film_person_id;
```