### PR TITLE
Add unique_together property for M2M tables; add SQL scripts

### DIFF
--- a/apps/webapp/models.py
+++ b/apps/webapp/models.py
@@ -61,6 +61,8 @@ class FilmPerson(models.Model):
         ordering = ['film', 'person']
         verbose_name = 'Film Character'
         verbose_name_plural = 'Film Characters'
+        unique_together = (('film', 'person'),)
+
 
 
 class FilmPlanet(models.Model):
@@ -74,6 +76,7 @@ class FilmPlanet(models.Model):
         ordering = ['film', 'planet']
         verbose_name = 'Film Planet'
         verbose_name_plural = 'Film Planets'
+        unique_together = (('film', 'planet'),)
 
 
 class Person(models.Model):

--- a/sql_scripts/alter_table_film_characters_to_film_person.sql
+++ b/sql_scripts/alter_table_film_characters_to_film_person.sql
@@ -1,0 +1,3 @@
+-- SQLite
+ALTER TABLE film_characters
+RENAME TO film_person;

--- a/sql_scripts/alter_table_film_person_pk_name.sql
+++ b/sql_scripts/alter_table_film_person_pk_name.sql
@@ -1,0 +1,3 @@
+-- SQLite
+ALTER TABLE film_characters
+RENAME COLUMN id TO film_person_id;

--- a/sql_scripts/create_tables.sql
+++ b/sql_scripts/create_tables.sql
@@ -1,0 +1,92 @@
+-- disable foreign key constraint check
+PRAGMA foreign_keys=off;
+
+BEGIN TRANSACTION;
+
+-- WARN: DROP OLD SCHEMAS ONLY
+-- DROP TABLE film_person;
+-- DROP TABLE film_planet;
+-- DROP TABLE film_species;
+-- DROP TABLE film_starship;
+-- DROP TABLE film_vehicle;
+
+CREATE TABLE IF NOT EXISTS film_person(
+    film_person_id INTEGER PRIMARY KEY,
+    film_id INTEGER NOT NULL,
+    person_id INTEGER NOT NULL,
+    FOREIGN KEY (film_id)
+        REFERENCES film (film_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION,
+    FOREIGN KEY (person_id)
+        REFERENCES person (person_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION --,
+    -- PRIMARY KEY (film_id, person_id)
+);
+
+CREATE TABLE IF NOT EXISTS film_planet(
+    film_planet_id INTEGER PRIMARY KEY,
+    film_id INTEGER NOT NULL,
+    planet_id INTEGER NOT NULL,
+    FOREIGN KEY (film_id)
+        REFERENCES film (film_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION,
+    FOREIGN KEY (planet_id)
+        REFERENCES planet (planet_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION --,
+    -- PRIMARY KEY (film_id, planet_id)
+);
+
+CREATE TABLE IF NOT EXISTS film_species(
+    film_species_id INTEGER PRIMARY KEY,
+    film_id INTEGER NOT NULL,
+    species_id INTEGER NOT NULL,
+    FOREIGN KEY (film_id)
+        REFERENCES film (film_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION,
+    FOREIGN KEY (species_id)
+        REFERENCES species (species_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION --,
+    -- PRIMARY KEY (film_id, species_id)
+);
+
+CREATE TABLE IF NOT EXISTS film_starship(
+    film_starship_id INTEGER PRIMARY KEY,
+    film_id INTEGER NOT NULL,
+    starship_id INTEGER NOT NULL,
+    FOREIGN KEY (film_id)
+        REFERENCES film (film_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION,
+    FOREIGN KEY (starship_id)
+        REFERENCES starship (starship_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION --,
+    -- PRIMARY KEY (film_id, starship_id)
+);
+
+CREATE TABLE IF NOT EXISTS film_vehicle(
+    film_vehicle_id INTEGER PRIMARY KEY,
+    film_id INTEGER NOT NULL,
+    vehicle_id INTEGER NOT NULL,
+    FOREIGN KEY (film_id)
+        REFERENCES film (film_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION,
+    FOREIGN KEY (vehicle_id)
+        REFERENCES vehicle (vehicle_id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION --,
+    -- PRIMARY KEY (film_id, vehicle_id)
+);
+
+-- commit transaction
+COMMIT;
+
+-- enable foreign key constraint check
+PRAGMA foreign_keys=on;

--- a/sql_scripts/drop_tables.sql
+++ b/sql_scripts/drop_tables.sql
@@ -1,0 +1,6 @@
+-- WARN: DROP OLD SCHEMAS ONLY
+DROP TABLE film_person;
+DROP TABLE film_planets;
+DROP TABLE film_species;
+DROP TABLE film_starships;
+-- DROP TABLE film_vehicle;


### PR DESCRIPTION
This PR adds the `unique_together` class variable to each M2M model's META class.  This property needs to be defined for every M2M model that we create.

The PR also adds sample SQLite SQL scripts.